### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-to-gandalf-production.yml
+++ b/.github/workflows/deploy-to-gandalf-production.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Nginx - Publish to Github Packages Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: kuclap/server-conf-nginx/kuclap-gandalf-nginx
           registry: docker.pkg.github.com


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore